### PR TITLE
Add MCP endpoint auth and tool controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@
 # (Optional: works without token at 60 req/hr. With token: 5,000 req/hr)
 
 # Optional
+# AGENTSCORE_ENABLED_TOOLS=agentscore,sweep
 # AGENTSCORE_CACHE_TTL=86400
 # AGENTSCORE_RATE_LIMIT_MS=200
 # AGENTSCORE_SITE_URL=https://ai-agent-score.vercel.app
@@ -25,6 +26,7 @@
 # AGENTSCORE_HTTP_HOST=127.0.0.1
 # AGENTSCORE_HTTP_PORT=8787
 # AGENTSCORE_HTTP_PATH=/mcp
+# AGENTSCORE_HTTP_AUTH_TOKEN=replace-with-strong-token
 # AGENTSCORE_AUDIT_TOKEN=replace-with-strong-token
 # AGENTSCORE_AUDIT_MAX_ENTRIES=500
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Run one shared governance endpoint for multiple clients:
 
 ```bash
 export AGENTSCORE_TRANSPORT=http
+export AGENTSCORE_ENABLED_TOOLS=agentscore,sweep
 export AGENTSCORE_HTTP_HOST=127.0.0.1
 export AGENTSCORE_HTTP_PORT=8787
 export AGENTSCORE_HTTP_PATH=/mcp
@@ -240,6 +241,17 @@ Service endpoints:
 - Policy snapshot: `http://127.0.0.1:8787/agentscore/policy`
 - Audit events: `http://127.0.0.1:8787/agentscore/audit`
 
+Optionally protect the MCP endpoint itself:
+
+```bash
+export AGENTSCORE_HTTP_AUTH_TOKEN=replace-with-strong-token
+```
+
+Then send one of:
+- `Authorization: Bearer <token>`
+- `x-agentscore-mcp-token: <token>`
+- `x-agentscore-token: <token>`
+
 Optionally protect policy/audit endpoints:
 
 ```bash
@@ -249,6 +261,12 @@ export AGENTSCORE_AUDIT_TOKEN=replace-with-strong-token
 Then call with either:
 - `Authorization: Bearer <token>`
 - `x-agentscore-audit-token: <token>`
+
+If your MCP client does not support direct remote Streamable HTTP servers, use a local bridge:
+
+```bash
+npx -y mcp-remote http://127.0.0.1:8787/mcp
+```
 
 ### Clean Onboarding (Recommended)
 
@@ -543,6 +561,7 @@ flowchart LR
 | Variable | Default | Description |
 |:---|:---:|:---|
 | `AGENTSCORE_ADAPTER` | `demo` | `demo` · `github` · `json` · `moltbook` |
+| `AGENTSCORE_ENABLED_TOOLS` | `agentscore,sweep` | Comma-separated tool allow-list (`agentscore`, `sweep`) |
 | `AGENTSCORE_TRANSPORT` | `stdio` | `stdio` or `http` (Streamable HTTP server mode) |
 | `AGENTSCORE_PUBLIC_MODE` | `false` | If `true`, requires explicit adapter and blocks `demo` |
 | `GITHUB_TOKEN` | — | GitHub PAT (optional, increases rate limit to 5,000/hr) |
@@ -554,6 +573,7 @@ flowchart LR
 | `AGENTSCORE_HTTP_HOST` | `127.0.0.1` | Bind host for HTTP transport |
 | `AGENTSCORE_HTTP_PORT` | `8787` | Bind port for HTTP transport |
 | `AGENTSCORE_HTTP_PATH` | `/mcp` | MCP endpoint path for HTTP transport |
+| `AGENTSCORE_HTTP_AUTH_TOKEN` | — | Optional bearer token required for `/mcp` HTTP endpoint |
 | `AGENTSCORE_AUDIT_TOKEN` | — | Optional bearer token required for policy/audit endpoints |
 | `AGENTSCORE_AUDIT_MAX_ENTRIES` | `500` | In-memory cap for retained policy audit events |
 | `AGENTSCORE_ENFORCE` | `false` | If `true`, policy gate can block risky results |

--- a/test/code-quality.test.mjs
+++ b/test/code-quality.test.mjs
@@ -132,6 +132,24 @@ assert(
   "Invalid transport error message is explicit"
 );
 
+const singleToolRun = spawnSync(process.execPath, ["-e", configScript], {
+  env: { ...process.env, AGENTSCORE_ADAPTER: "demo", AGENTSCORE_ENABLED_TOOLS: "agentscore" },
+  encoding: "utf-8",
+});
+
+assert(singleToolRun.status === 0, `Single-tool allow-list loads config: ${singleToolRun.status}`);
+
+const badToolsRun = spawnSync(process.execPath, ["-e", configScript], {
+  env: { ...process.env, AGENTSCORE_ADAPTER: "demo", AGENTSCORE_ENABLED_TOOLS: "agentscore,badtool" },
+  encoding: "utf-8",
+});
+
+assert(badToolsRun.status === 42, `Invalid tool allow-list exits with code 42: ${badToolsRun.status}`);
+assert(
+  (badToolsRun.stderr || "").includes("AGENTSCORE_ENABLED_TOOLS contains invalid tools"),
+  "Invalid tool allow-list error message is explicit"
+);
+
 const publicModeMissingAdapterRun = spawnSync(process.execPath, ["-e", configScript], {
   env: { ...process.env, AGENTSCORE_ADAPTER: "", AGENTSCORE_PUBLIC_MODE: "true" },
   encoding: "utf-8",

--- a/test/public-contract.test.mjs
+++ b/test/public-contract.test.mjs
@@ -42,9 +42,10 @@ const packageName = pkg.name;
 
 const installMatches = [...readme.matchAll(/npx -y ([\w@./-]+)/g)];
 assert(installMatches.length >= 1, "README contains npx install command");
+const agentScoreInstallMatches = installMatches.filter((m) => m[1] === packageName);
 assert(
-  installMatches.every((m) => m[1] === packageName),
-  `README install command uses package name (${packageName})`
+  agentScoreInstallMatches.length >= 1,
+  `README includes install command using package name (${packageName})`
 );
 
 assert(


### PR DESCRIPTION
Summary: add per-tool controls, optional auth for HTTP MCP endpoint, remote bridge docs, and config validation tests. Validation: npm run test passed.