### PR TITLE
Release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-02-09
+
 ### Added
 - Optional enforce-mode policy gate (`AGENTSCORE_ENFORCE` / `--enforce`) that can block risky `agentscore` and `sweep` responses.
 - Structured JSON audit events for policy decisions (`[agentscore][audit] ...`) with reasons and effective policy snapshot.
@@ -21,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README and `.env.example` now document policy-gate controls (score thresholds, blocked recommendations/threat levels, trusted adapters, fail-on-errors, audit toggles).
 - Public readiness test suite now includes enforce-mode regression coverage for both tools.
 - Configuration now supports transport/audit endpoint settings and in-memory audit retention limits.
+- Added optional MCP endpoint auth token (`AGENTSCORE_HTTP_AUTH_TOKEN`) and per-tool allow-listing (`AGENTSCORE_ENABLED_TOOLS`) for tighter production control.
+- Added remote bridge setup guidance (`mcp-remote`) for clients that do not yet support direct remote Streamable HTTP MCP.
 
 ## [1.0.4] - 2026-02-09
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscore-mcp",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Trust scoring for AI agents. Investigate, verify, and compare agent trustworthiness through MCP.",
   "author": "Tripti Mishra",
   "license": "MIT",

--- a/release-notes/v1.0.5.md
+++ b/release-notes/v1.0.5.md
@@ -1,0 +1,18 @@
+## AgentScore MCP v1.0.5
+
+This release focuses on production control for centralized MCP deployments.
+
+### Highlights
+- Added optional hard auth for the Streamable HTTP MCP endpoint:
+  - `AGENTSCORE_HTTP_AUTH_TOKEN`
+  - accepts `Authorization: Bearer`, `x-agentscore-mcp-token`, or `x-agentscore-token`
+- Added per-tool exposure control:
+  - `AGENTSCORE_ENABLED_TOOLS=agentscore,sweep`
+  - allows deploying only the tool(s) needed in each environment
+- Expanded centralized service docs with:
+  - MCP endpoint auth setup
+  - `mcp-remote` bridge guidance for clients without direct remote HTTP MCP support
+- Added config regression tests for tool allow-list validation and updated README install-link contract tests.
+
+### Validation
+- `npm run verify` passing locally before tagging.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENTSCORE_VERSION = "1.0.4";
+export const AGENTSCORE_VERSION = "1.0.5";


### PR DESCRIPTION
Release v1.0.5: MCP endpoint auth token, tool allow-list controls, docs/tests updates.