### PR TITLE
Release v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-02-09
+
+### Added
+- Enterprise demo dataset for JSON adapter flows at `examples/enterprise-demo.json` (4 business-oriented agents + 1 evaluation thread).
+- Plain badge URL output (`badge.url`) alongside markdown badge output (`badge.markdown`) for terminal/MCP clients that do not render markdown images.
+- Generated HTML governance card artifact on every score result (`artifacts.governanceCardHtml`) for copy/paste into internal governance wikis or portals.
+- New report-link policy mode `none` (default) via `AGENTSCORE_REPORT_URL_MODE`.
+
+### Changed
+- MCP text output now includes:
+  - `Badge URL`
+  - `Badge Markdown`
+  - `Governance Card (HTML)` block
+- Public report links are no longer shown in default human-readable MCP output.
+- Default report-link behavior is now `AGENTSCORE_REPORT_URL_MODE=none` to avoid dead external links for private/custom handles.
+
+### Fixed
+- Removed non-working dashboard link experiences for enterprise JSON handles by suppressing report URLs unless explicitly enabled.
+
 ## [1.0.5] - 2026-02-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscore-mcp",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Trust scoring for AI agents. Investigate, verify, and compare agent trustworthiness through MCP.",
   "author": "Tripti Mishra",
   "license": "MIT",

--- a/release-notes/v1.0.6.md
+++ b/release-notes/v1.0.6.md
@@ -1,0 +1,23 @@
+## AgentScore MCP v1.0.6
+
+This release makes enterprise output safer and more usable by default: no accidental dead public dashboard links, better badge interoperability, and ready-to-paste governance artifacts.
+
+### Highlights
+- Added enterprise JSON demo dataset:
+  - `examples/enterprise-demo.json`
+  - includes 4 business-focused agents and 1 thread for `sweep`
+- Improved badge outputs for MCP/terminal clients:
+  - added `badge.url` (plain clickable URL)
+  - added `badge.markdown`
+  - retained `badge.shields` for backward compatibility
+- Added generated HTML governance artifact on each score:
+  - `artifacts.governanceCardHtml`
+  - included in MCP text output as a fenced `html` block
+- Updated report-link policy defaults:
+  - new default `AGENTSCORE_REPORT_URL_MODE=none`
+  - optional overrides remain `demo-only` and `always`
+  - default MCP text response no longer includes public `Report` links
+
+### Validation
+- `npm test` passing.
+- `npm run verify` passing before tag push.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENTSCORE_VERSION = "1.0.5";
+export const AGENTSCORE_VERSION = "1.0.6";


### PR DESCRIPTION
## Summary
- bump package version to 1.0.6
- update runtime version constant
- update CHANGELOG with 1.0.6 entries
- add release notes at release-notes/v1.0.6.md

## Validation
- npm run verify