### PR TITLE
Release v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-02-09
+
+### Changed
+- Removed public dashboard URL coupling from score generation and config:
+  - dropped `reportUrl` from score output payloads
+  - removed `AGENTSCORE_SITE_URL` and `AGENTSCORE_REPORT_URL_MODE`
+- MCP `agentscore` responses now standardize on:
+  - trust badge URL/markdown
+  - governance card HTML artifact
+- Added response-level URL sanitization guard to redact accidental `ai-agent-score.vercel.app` links in tool text output.
+- Strengthened `sweep` enterprise coordination detection for low-trust cohorts and clustered timing patterns.
+- Updated README, launch kit docs, and public contract tests to align with the no-dashboard-link output contract.
+
 ## [1.0.6] - 2026-02-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscore-mcp",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Trust scoring for AI agents. Investigate, verify, and compare agent trustworthiness through MCP.",
   "author": "Tripti Mishra",
   "license": "MIT",

--- a/release-notes/v1.0.7.md
+++ b/release-notes/v1.0.7.md
@@ -1,0 +1,20 @@
+## AgentScore MCP v1.0.7
+
+This release finalizes the public-output hardening work so MCP responses stay enterprise-safe by default and do not leak public dashboard URLs.
+
+### Highlights
+- Removed public dashboard URL coupling from runtime scoring output:
+  - removed `reportUrl` from score payloads
+  - removed `AGENTSCORE_SITE_URL` and `AGENTSCORE_REPORT_URL_MODE`
+- Kept output focused on governance artifacts that work in private environments:
+  - `badge.url` and `badge.markdown`
+  - `artifacts.governanceCardHtml`
+- Added a defensive output sanitizer in `agentscore` tool text rendering to redact accidental `ai-agent-score.vercel.app` URLs.
+- Improved enterprise thread sweep detection:
+  - clustered timing heuristic for low-trust participants
+  - elevated-risk cohort detection when multiple participants score below 550
+
+### Validation
+- `npm test` passing
+- `npm run verify` passing
+- `npm run benchmark:strict` passing

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENTSCORE_VERSION = "1.0.6";
+export const AGENTSCORE_VERSION = "1.0.7";


### PR DESCRIPTION
## Summary
- bump package/runtime version to 1.0.7
- document release in CHANGELOG and release notes
- publish public-output hardening updates from #16

## Validation
- npm run verify
- npm run benchmark:strict