### PR TITLE
Align high-stakes access decisions with trust signals

### DIFF
--- a/src/scoring/briefing.ts
+++ b/src/scoring/briefing.ts
@@ -53,7 +53,7 @@ export function generateBriefing(
     if (flags.length > 0) {
       sentences.push(flags.slice(0, 2).join(". ") + ".");
     }
-    sentences.push("Exercise caution.");
+    sentences.push(buildPoorTierDecision(flags, categories));
   } else {
     // Critical
     sentences.push(buildCriticalOpener(flags));
@@ -157,4 +157,18 @@ function buildCriticalEvidence(
   }
 
   return parts.length > 0 ? parts.join(". ") + "." : "Subject fails multiple trust indicators.";
+}
+
+function buildPoorTierDecision(flags: string[], categories: CategoryScore[]): string {
+  const risk = categories.find((c) => c.name === "Risk Signals");
+  const text = [risk?.topSignal ?? "", ...flags].join(" ").toLowerCase();
+  const hasHardStop =
+    text.includes("manipulation keyword") ||
+    text.includes("prompt injection") ||
+    text.includes("account not claimed");
+
+  if (hasHardStop || (risk?.score ?? 100) < 55) {
+    return "Do not onboard without remediation and re-score.";
+  }
+  return "Exercise caution.";
 }

--- a/src/scoring/types.ts
+++ b/src/scoring/types.ts
@@ -12,6 +12,7 @@ export interface AgentScoreResult {
   score: number;
   tier: Tier;
   recommendation: Recommendation;
+  accessDecision: AccessDecision;
   confidence: Confidence;
   categories: CategoryScore[];
   briefing: string;
@@ -37,6 +38,11 @@ export interface ComparisonResult {
 export type Tier = "Excellent" | "Good" | "Fair" | "Poor" | "Critical";
 export type Recommendation = "TRUST" | "CAUTION" | "AVOID";
 export type Confidence = "high" | "medium" | "low";
+export type AccessDecision = {
+  verdict: "ALLOW" | "CONDITIONAL" | "REJECT";
+  label: string;
+  rationale: string[];
+};
 
 export interface ScoringContext {
   handle: string;

--- a/src/tools/agentscore.ts
+++ b/src/tools/agentscore.ts
@@ -72,6 +72,13 @@ function sanitizeOutputText(text: string): string {
   return text.replace(/https?:\/\/ai-agent-score\.vercel\.app[^\s)"]*/gi, "<redacted-url>");
 }
 
+function formatAccessDecision(decision: AgentScoreResult["accessDecision"]): string {
+  const leadReason = decision.rationale[0] || "No additional rationale.";
+  const extraCount = Math.max(0, decision.rationale.length - 1);
+  const suffix = extraCount > 0 ? ` (+${extraCount} more checks)` : "";
+  return `**Access Decision:** ${decision.label} — ${leadReason}${suffix}`;
+}
+
 export function registerAgentScoreTool(
   server: McpServer,
   getAdapter: (platform?: string) => AgentPlatformAdapter,
@@ -187,6 +194,7 @@ export function registerAgentScoreTool(
         textParts.push(
           `## @${r.handle} — ${r.score}/850 (${r.tier})\n` +
             `**Recommendation:** ${r.recommendation} | **Confidence:** ${r.confidence}\n\n` +
+            `${formatAccessDecision(r.accessDecision)}\n\n` +
             `${r.briefing}\n\n` +
             `**Categories:**\n` +
             r.categories


### PR DESCRIPTION
## Summary
- add explicit accessDecision output (ALLOW / CONDITIONAL / REJECT) to scored agents
- keep recommendation tier output for compatibility while making go/no-go intent explicit
- tighten poor-tier briefing language for hard-stop risk patterns
- add regression test asserting enterprise consistency: claims-assist-v3 stays CONDITIONAL, quickquote-express is REJECT
- keep MCP output concise with a one-line decision rationale to avoid extra noise

## Validation
- npm test
- npm run verify