### PR TITLE
Release v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-02-09
+
+### Changed
+- Added explicit `accessDecision` output to scored agents with clear deployment intent:
+  - `ALLOW - STANDARD GUARDRAILS`
+  - `CONDITIONAL - SUPERVISED ONLY`
+  - `REJECT - DO NOT ONBOARD`
+- Aligned high-stakes output narratives with risk signals so hard-stop profiles are consistently marked as reject.
+- Kept MCP response noise low by rendering access decision as a concise one-line summary.
+
+### Tests
+- Added enterprise regression coverage to ensure:
+  - `@claims-assist-v3` remains `CONDITIONAL`
+  - `@quickquote-express` is `REJECT` when manipulation and severe risk signals are present.
+
 ## [1.0.7] - 2026-02-09
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscore-mcp",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscore-mcp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Trust scoring for AI agents. Investigate, verify, and compare agent trustworthiness through MCP.",
   "author": "Tripti Mishra",
   "license": "MIT",

--- a/release-notes/v1.0.8.md
+++ b/release-notes/v1.0.8.md
@@ -1,0 +1,19 @@
+## AgentScore MCP v1.0.8
+
+This patch improves decision consistency for enterprise governance by separating tier recommendation from explicit access decisions.
+
+### Highlights
+- Added explicit `accessDecision` on each scored agent:
+  - `ALLOW - STANDARD GUARDRAILS`
+  - `CONDITIONAL - SUPERVISED ONLY`
+  - `REJECT - DO NOT ONBOARD`
+- Aligned high-stakes narrative wording with hard-stop risk signals so severe cases are clearly rejected.
+- Kept output concise by showing a one-line decision summary with primary rationale (plus count of additional checks).
+
+### Why this matters
+- Prevents confusing cases where a broad recommendation label (for compatibility) appears softer than the actual go/no-go decision.
+- Makes outputs easier to use in vendor review and PII/PHI access workflows.
+
+### Validation
+- `npm test` passing
+- `npm run verify` passing

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENTSCORE_VERSION = "1.0.7";
+export const AGENTSCORE_VERSION = "1.0.8";


### PR DESCRIPTION
## Summary
- bump package/runtime version to 1.0.8
- document release in CHANGELOG and release notes
- publish access-decision consistency improvements from #18

## Validation
- npm test
- npm run verify
- npm run benchmark:strict